### PR TITLE
[Feat] Add Player Dash, Dash State

### DIFF
--- a/Assets/03_Scripts/PlayerScripts/PlayerState/PlayerDashState.cs
+++ b/Assets/03_Scripts/PlayerScripts/PlayerState/PlayerDashState.cs
@@ -1,0 +1,62 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PlayerDashState : PlayerBaseState
+{
+    private float _timer;
+    private Vector2 _dashDir;
+
+    public PlayerDashState(PlayerController controller, PlayerStateMachine stateMachine) : base(controller, stateMachine)
+    {
+    }
+
+    public override void Enter()
+    {
+        _timer = 0f;
+
+        // 플레이어의 이동 방향을 대쉬 방향에 대입
+        if (_playerController.HasMoveInput)
+        {
+            _dashDir = _playerController.MoveInput;
+        }
+
+        // 대쉬 시작, 쿨타임 적용
+        _playerController.StartDash(_dashDir);
+
+        // 대쉬 상태 전환
+        _playerController.DashStateChange();
+
+        // TODO: 대쉬 애니메이션 추가
+    }
+
+    public override void Update()
+    {
+        _timer += Time.deltaTime;
+
+        // 대쉬 지속 시간 경과 후 상태 전환
+        if (_timer >= _playerController.DashDuration)
+        {
+            // 대쉬 후 이동 입력이 있으면 MoveState 상태로 전환, 아니면 IdleState 전환
+            if (_playerController.HasMoveInput)
+            {
+                _playerStateMachine.ChangeState(_playerController.PlayerMoveState);
+            }
+            else
+            {
+                _playerStateMachine.ChangeState(_playerController.PlayerIdleState);
+            }
+        }
+    }
+
+    public override void FixedUpdate()
+    {
+        // 대쉬 이동
+        _playerController.MoveDash(_dashDir);
+    }
+
+    public override void Exit()
+    {
+        _playerController.StopMove();
+    }
+}

--- a/Assets/03_Scripts/PlayerScripts/PlayerState/PlayerDashState.cs.meta
+++ b/Assets/03_Scripts/PlayerScripts/PlayerState/PlayerDashState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c1be7ce4a55b9d649829005fdcbdbc82
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/03_Scripts/PlayerScripts/PlayerState/PlayerMoveState.cs
+++ b/Assets/03_Scripts/PlayerScripts/PlayerState/PlayerMoveState.cs
@@ -15,6 +15,13 @@ public class PlayerMoveState : PlayerBaseState
 
     public override void Update()
     {
+        // 대쉬 입력이 있으면 DashState로 상태 전환
+        if (_playerController.IsDash && _playerController.CanDash)
+        {
+            _playerStateMachine.ChangeState(_playerController.PlayerDashState);
+            return;
+        }
+
         // 이동 입력이 없으면 IdleState로 상태 전환
         if (!_playerController.HasMoveInput)
         {

--- a/Assets/03_Scripts/PlayerScripts/PlayerStateMachine.cs
+++ b/Assets/03_Scripts/PlayerScripts/PlayerStateMachine.cs
@@ -20,6 +20,7 @@ public class PlayerStateMachine
 
         _currentState?.Exit();  // 현재 상태 끝
         _currentState = changeState;    // 변경 요청 상태를 현재 상태로 변경
+        Debug.Log($"플레이어의 상태 : {_currentState}");
         _currentState?.Enter(); // 현재 상태 시작
     }
 

--- a/Assets/04_Scenes/SampleScene.unity
+++ b/Assets/04_Scenes/SampleScene.unity
@@ -623,6 +623,9 @@ MonoBehaviour:
     _currentHp: 0
     _moveSpeed: 5
   _gunController: {fileID: 948649910}
+  _dashSpeed: 10
+  _dashDuration: 0.3
+  _dashCoolTime: 2
 --- !u!58 &613101768
 CircleCollider2D:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
1. 플레이어의 대쉬 상태 추가 및 대쉬 사용 구현

- PlayerDashState
- 이동 입력이 없는 Idle 상태에서는 Dash사용 금지
- 이동 입력 방향에 대쉬 이동
- 대쉬 CoolTime을 타이머로 하지 않고 대쉬를 사용한 시간을 저장하고 쿨타임을 더한 시간을 CanDash로 두어 사용

## 체크리스트
- [x] 코드가 정상적으로 빌드/실행된다
- [x] 기능이 정상 동작한다
- [x] 심각한 버그나 예상치 못한 문제는 없다