### PR TITLE
[Feat] Add Room Controller

### DIFF
--- a/Assets/03_Scripts/RoomScripts.meta
+++ b/Assets/03_Scripts/RoomScripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2592c88a835563544a71962a40db64da
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/03_Scripts/RoomScripts/RoomController.cs
+++ b/Assets/03_Scripts/RoomScripts/RoomController.cs
@@ -1,0 +1,120 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class RoomController : MonoBehaviour
+{
+    [Header("Room Info")]
+    [SerializeField] private string _roomId;
+    [SerializeField] private bool _enemySpawnOn = true;
+
+    [Header("Player Detect")]
+    [SerializeField] private string _playerTag = "Player";
+
+    [Header("Enemy Spawn Setting")]
+    [SerializeField] private EnemyController _enemyPrefab;
+    [SerializeField] private List<Transform> _enemySpawnList = new List<Transform>();
+
+    [Header("Door Interaction Setting")]
+    [SerializeField] private GameObject _doorTriggerBlock;
+
+    private readonly List<EnemyController> _spawnEnemys = new List<EnemyController>();
+
+    private bool _isRoomActivate;
+    private bool _isRoomClear;
+    private Collider2D _enterTrigger;
+
+    private void Awake()
+    {
+        _enterTrigger = GetComponent<Collider2D>();
+    }
+
+    private void Update()
+    {
+        // 방이 활성화 되어 있지 않거나 클리어하면 실행하지 않음
+        if (!_isRoomActivate || _isRoomClear) return;
+
+        // 방에 생성된 적이 모두 죽었는지 확인
+        if (AllEnemyDeadCheck())
+        {
+            // 적이 모두 죽었으면 클리어
+            RoomClear();
+        }
+    }
+
+    private void OnTriggerEnter2D(Collider2D collision)
+    {
+        // 몬스터 스폰이 꺼져있고 이미 룸에 진입했으며 플레이어가 아니면 실행하지 않음
+        if (!_enemySpawnOn || _isRoomActivate || !collision.CompareTag("Player")) return;
+
+        // 방 활성화
+        ActivateRoom();
+    }
+
+    // 방 활성화, 전투 시작
+    public void ActivateRoom()
+    {
+        // 이미 방이 활성화가 되어 있으면 실행하지 않음
+        if (_isRoomActivate) return;
+
+        _isRoomActivate = true;
+
+        // 문 닫기
+        if (_doorTriggerBlock != null)
+        {
+            _doorTriggerBlock.SetActive(true);
+        }
+
+        // 몬스터 생성
+        SpawnEnemies();
+    }
+
+    // 몬스터 생성
+    private void SpawnEnemies()
+    {
+        // 리스트에 몬스터가 있을 시 삭제
+        _spawnEnemys.Clear();
+
+        // 스폰 포인트를 순회
+        foreach(var spawnPoint in _enemySpawnList)
+        {
+            if (spawnPoint == null || _enemyPrefab == null) continue;
+
+            // 스폰 포인트에 몬스터 생성
+            EnemyController enemy = Instantiate(_enemyPrefab, spawnPoint.position, spawnPoint.rotation);
+
+            // 생성된 몬스터 리스트에 해당 몬스터 저장
+            _spawnEnemys.Add(enemy);
+        }
+    }
+
+    // 몬스터의 사망 확인
+    private bool AllEnemyDeadCheck()
+    {
+        // 적의 상태 확인
+        for(int i = 0; i < _spawnEnemys.Count; i++)
+        {
+            EnemyController enemy = _spawnEnemys[i];
+
+            // 적이 살아있으면
+            if (enemy != null && !enemy.IsDead) return false;
+        }
+
+        // 적이 모두 죽었으면
+        return true;
+    }
+
+    // 방 클리어
+    private void RoomClear()
+    {
+        _isRoomClear = true;
+
+        // 문 열기
+        if (_doorTriggerBlock != null)
+        {
+            _doorTriggerBlock.SetActive(false);
+        }
+
+        Debug.Log($"Room-{_roomId} Clear");
+    }
+}

--- a/Assets/03_Scripts/RoomScripts/RoomController.cs.meta
+++ b/Assets/03_Scripts/RoomScripts/RoomController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f21e4a09d8853b844b628bbbb3bf8f40
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- 플레이어가 방에 입장하게 되면 몬스터를 소환하고 몬스터가 전부 사망하면 클리어하는 로직 구현

- Room Controller
- 플레이어가 방에 진입하면 Trigger 체크를 하며 문을 닫고 
- 방 프리펩의 생성 몬스터 리스트를 순회 하면서 몬스터를 소환

## 체크리스트
- [x] 코드가 정상적으로 빌드/실행된다
- [x] 기능이 정상 동작한다
- [x] 심각한 버그나 예상치 못한 문제는 없다